### PR TITLE
Fix React Router 404 on Vercel Refresh

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,5 @@
+{
+  "rewrites": [
+    { "source": "/(.*)", "destination": "/" }
+  ]
+}


### PR DESCRIPTION
📌 Description :

This PR fixes the issue where refreshing any client-side route (e.g. /home, /about) on the deployed React app returned a 404 Not Found error.

Added a vercel.json config file at the project root.

Configures Vercel to rewrite all unknown routes to /index.html, ensuring React Router can handle client-side navigation correctly.

🛠 Changes Made

Added vercel.json file with the following config:

{
  "rewrites": [
    { "source": "/(.*)", "destination": "/" }
  ]
}


Ensured file is placed in the project root (same level as package.json).

✅ How It Fixes the Issue

Previously: Refreshing /home or directly visiting /about caused 404 Not Found because Vercel tried to resolve those as static files.

Now: Any unknown route automatically serves index.html, letting React Router render the correct component.

🔎 Testing Done

Deployed to Vercel.

Verified routes:

/ → Loads Home page.

/home → Loads Home page, no 404 on refresh.

/about → Loads About page, no 404 on refresh.

🚀 Impact

Users can now refresh or directly visit deep links (like /home, /about, /dashboard) without errors.

Improves reliability of navigation in production deployment.